### PR TITLE
[Feat] 언제나 가까이 ~ 하단배너 UI 디테일 구현

### DIFF
--- a/GsHometown-iOS/GsHometown-iOS/Common/Extension/UICollectionViewLayout+.swift
+++ b/GsHometown-iOS/GsHometown-iOS/Common/Extension/UICollectionViewLayout+.swift
@@ -159,6 +159,7 @@ extension UICollectionViewLayout {
         let backgroundItem = NSCollectionLayoutDecorationItem.background(elementKind: ServiceReusableView.identifier)
         section.decorationItems = [backgroundItem]
         section.contentInsets.top = 52
+        section.contentInsets.bottom = 8
 
         return section
     }
@@ -171,7 +172,6 @@ extension UICollectionViewLayout {
         )
         let largeItem = NSCollectionLayoutItem(layoutSize: largeSize)
 
-        let groupHeight: CGFloat = 270
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.65),
             heightDimension: .fractionalHeight(0.3)
@@ -185,12 +185,13 @@ extension UICollectionViewLayout {
 
         section.orthogonalScrollingBehavior = .none
         section.contentInsets = .init(
-            top: 71,
+            top: 91,
             leading: 16,
             bottom: 14,
             trailing: 0
         )
         let backgroundItem = NSCollectionLayoutDecorationItem.background(elementKind: EventReusableView.identifier)
+        backgroundItem.contentInsets.top = 20
         section.decorationItems = [backgroundItem]
 
         return section

--- a/GsHometown-iOS/GsHometown-iOS/View/Home/Cell/EventOfTheWeekCell.swift
+++ b/GsHometown-iOS/GsHometown-iOS/View/Home/Cell/EventOfTheWeekCell.swift
@@ -11,6 +11,7 @@ final class EventOfTheWeekCell: UICollectionViewCell {
 
     private let titleLabel: UILabel = UILabel()
     private let subTitleLabel: UILabel = UILabel()
+    private let arrowImageView: UIImageView = UIImageView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,6 +26,7 @@ final class EventOfTheWeekCell: UICollectionViewCell {
 
     private func setStyle() {
         self.backgroundColor = .white
+        self.layer.cornerRadius = 20
         titleLabel.do {
             $0.text = "GS더프레시 행사전단"
             $0.font = GSFont.h4
@@ -35,11 +37,15 @@ final class EventOfTheWeekCell: UICollectionViewCell {
             $0.font = GSFont.b3m
             $0.textColor = GSColor.grey08
         }
+        arrowImageView.do {
+            $0.image = GSImage.arrowRight
+        }
     }
 
     private func setUI() {
         self.addSubview(titleLabel)
         self.addSubview(subTitleLabel)
+        self.addSubview(arrowImageView)
     }
 
     private func setAutoLayout() {
@@ -50,6 +56,10 @@ final class EventOfTheWeekCell: UICollectionViewCell {
         subTitleLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(12)
             $0.leading.equalToSuperview().inset(16)
+        }
+        arrowImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 메인 페이지 UI의 디테일을 구현했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-iOS/assets/49385546/603649e1-da57-43f4-8ccd-9d7276eacc99" width="200"/>
<img src="https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-iOS/assets/49385546/26bcd0d6-72ba-4919-a180-b754833b85cc" width="200"/>

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 일부 버튼의 UI 뭉개짐 현상은 이미지 에셋을 그대로 넣어 생기는 현상입니다.
- 이러한 문제는 이후 시간적 여유가 생길 때 해결할 예정입니다!

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 이해 안가는 부분이 있으시면 리뷰 남겨주세용!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #8 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
