### PR TITLE
[Feat] DetailView API 연결

### DIFF
--- a/GsHometown-iOS/GsHometown-iOS/Network/APITarget/APITarget+Likes.swift
+++ b/GsHometown-iOS/GsHometown-iOS/Network/APITarget/APITarget+Likes.swift
@@ -22,7 +22,7 @@ extension APITarget.Likes: TargetType {
     }
     
     var path: String {
-        return "/api/likes"
+        return "api/likes"
     }
     
     var method: Moya.Method {

--- a/GsHometown-iOS/GsHometown-iOS/Network/APITarget/APITarget+Products.swift
+++ b/GsHometown-iOS/GsHometown-iOS/Network/APITarget/APITarget+Products.swift
@@ -22,7 +22,12 @@ extension APITarget.Products: TargetType {
     }
 
     var path: String {
-        return "/api/products"
+        switch self {
+        case .getPreorderInfo:
+            return "api/products"
+        case .getDetailProduct(let getDetailProductRequest):
+            return "api/products/\(getDetailProductRequest.productId)"
+        }
     }
 
     var method: Moya.Method {
@@ -36,11 +41,8 @@ extension APITarget.Products: TargetType {
                 parameters: ["type": getPreorderInfoRequest.type],
                 encoding: URLEncoding.default
             )
-        case .getDetailProduct(let getDetailProductRequest):
-            return .requestParameters(
-                parameters: ["productId": getDetailProductRequest.productId],
-                encoding: URLEncoding.default
-            )
+        case .getDetailProduct:
+            return .requestPlain
         }
     }
 
@@ -56,3 +58,4 @@ extension APITarget.Products: TargetType {
         }
     }
 }
+

--- a/GsHometown-iOS/GsHometown-iOS/Network/DTO/Response/DTO+GetDetailProductResponse.swift
+++ b/GsHometown-iOS/GsHometown-iOS/Network/DTO/Response/DTO+GetDetailProductResponse.swift
@@ -9,6 +9,13 @@ import Foundation
 
 extension DTO {
     struct GetDetailProductResponse: Codable {
+        let status: Int
+        let data: ProductDetail
+    }
+}
+
+extension DTO.GetDetailProductResponse {
+    struct ProductDetail: Codable {
         let thumbnail: String
         let title: String
         let isLiked: Bool

--- a/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
+++ b/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
@@ -27,6 +27,7 @@ class DetailViewController: UIViewController {
     private let contentView = UIView()
     private let mainImage = UIImageView().then {
         $0.image = GSImage.mockDetailMain
+        $0.contentMode = .scaleAspectFit
     }
     private let infoStackView = UIStackView().then{
         $0.axis = .vertical
@@ -103,6 +104,7 @@ class DetailViewController: UIViewController {
     }
     private let detailImage = UIImageView().then {
         $0.image = GSImage.mockDetailInfo
+        $0.contentMode = .scaleAspectFit
     }
     private let tabBar = DetailTabBarView()
     
@@ -158,7 +160,7 @@ class DetailViewController: UIViewController {
             $0.top.equalTo(mainImage.snp.bottom).offset(15)
             $0.leading.equalToSuperview().inset(15)
             $0.height.equalTo(53)
-            $0.width.equalTo(170)
+            $0.width.equalTo(280)
         }
         buttonStackView.snp.makeConstraints{
             $0.top.equalTo(mainImage.snp.bottom).offset(6)

--- a/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
+++ b/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import Kingfisher
 
 class DetailViewController: UIViewController {
     
@@ -112,6 +113,7 @@ class DetailViewController: UIViewController {
         setUI()
         setAutolayout()
         setNavigation()
+        getDetailData()
     }
     
     @objc func heartButtonTapped() {
@@ -204,5 +206,31 @@ class DetailViewController: UIViewController {
     
     private func setNavigation() {
         navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    func getDetailData() {
+        let apiProvider = APIProvider<APITarget.Products>()
+        apiProvider.request(DTO.GetDetailProductResponse.self,
+                                target: .getDetailProduct(DTO.GetDetailProductRequest(memberId: 1, productId: 3))) { [weak self] response in
+                    guard let self = self else { return }
+            switch response {
+            case .success(let response):
+                self.updateUI(with: response.data)
+            default:
+                response.statusDescription()
+            }
+        }
+    }
+    
+    private func updateUI(with response: DTO.GetDetailProductResponse.ProductDetail) {
+        let thumbnailURL = URL(string: response.thumbnail)
+        let detailURL = URL(string: response.detailImage)
+        self.mainImage.kf.setImage(with: thumbnailURL)
+        self.mainLabel.text = response.title
+        self.isTouched = response.isLiked
+        self.priceLabel.text = "\(response.price)원"
+        self.receiptAbleLabel.text = response.isReceiveAvailable ? "수령 가능" : "수령 불가"
+        self.reviewNumberLabel.text = "(\(response.reviewCount))"
+        self.detailImage.kf.setImage(with: detailURL)
     }
 }

--- a/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
+++ b/GsHometown-iOS/GsHometown-iOS/View/Detail/DetailViewController.swift
@@ -119,7 +119,11 @@ class DetailViewController: UIViewController {
     }
     
     @objc func heartButtonTapped() {
-        isTouched.toggle()
+        if isTouched {
+            deleteLikeData()
+        } else {
+            postLikeData()
+        }
     }
     
     private func setUI() {
@@ -234,5 +238,33 @@ class DetailViewController: UIViewController {
         self.receiptAbleLabel.text = response.isReceiveAvailable ? "수령 가능" : "수령 불가"
         self.reviewNumberLabel.text = "(\(response.reviewCount))"
         self.detailImage.kf.setImage(with: detailURL)
+    }
+    
+    private func postLikeData() {
+        let apiProvider = APIProvider<APITarget.Likes>()
+        let request = DTO.PostLikeRequest(memberId: 1, productId: 3)
+        apiProvider.request(.postLike(request)) { [weak self] response in
+            guard let self = self else { return }
+            switch response {
+            case .success:
+                self.isTouched = true
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+
+    private func deleteLikeData() {
+        let apiProvider = APIProvider<APITarget.Likes>()
+        let request = DTO.DeleteLikeRequest(memberId: 1, productId: 3)
+        apiProvider.request(.deleteLike(request)) { [weak self] response in
+            guard let self = self else { return }
+            switch response {
+            case .success:
+                self.isTouched = false
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 상세페이지 화면 조회 API를 연결했습니다.
- 상세페이지 좋아요 추가 및 삭제 API를 연결했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-iOS/assets/84556636/e42fb55f-1c99-48a1-ab09-b58d1b971d9b" width="200" height="400"/>
<img src="https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-iOS/assets/84556636/9e9977e6-5df2-4f90-aacd-bbae9f584f87" width="200" height="400"/>

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 이전에 계속 디코딩오류가 나서, APITarget의 Path와 Task 변경한 부분 확인 부탁드립니다!
- 현재는 productId에 정수값을 넣었는데, 추후에 cell의 indexPath를 넣어 코드를 수정하는게 맞는지 궁금합니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #35 
- close #43 